### PR TITLE
Persist strategy sessions

### DIFF
--- a/app/strategy/page.tsx
+++ b/app/strategy/page.tsx
@@ -3,6 +3,13 @@
 import { useEffect, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { ArrowUpIcon } from 'lucide-react'
+import SessionHistory from '@/components/strategy/session-history'
+import {
+  getSessionHistory,
+  saveSessionHistory,
+  getLastSessionId,
+  saveLastSessionId,
+} from '@/utils/session-cookie'
 import { Button } from '@/components/ui/button'
 import AICollaboration from '@/components/strategy/ai-collaboration'
 import BacktestingResults from '@/components/strategy/backtesting-results'
@@ -17,6 +24,9 @@ export default function StrategyPage() {
   const { authenticated, user } = usePrivy()
   const sessionId = useStrategyStore((state) => state.sessionId)
   const setSessionId = useStrategyStore((state) => state.setSessionId)
+  const sessionHistory = useStrategyStore((s) => s.sessionHistory)
+  const setSessionHistory = useStrategyStore((s) => s.setSessionHistory)
+  const addSessionToHistory = useStrategyStore((s) => s.addSessionToHistory)
   const apiVersion = useStrategyStore((s) => s.apiVersion)
   const setApiVersion = useStrategyStore((s) => s.setApiVersion)
   const backtestStatus = useStrategyStore((s) => s.backtestStatus)
@@ -34,6 +44,24 @@ export default function StrategyPage() {
     sessionId: sessionId || '',
     apiVersion: apiVersion,
   })
+
+  useEffect(() => {
+    const history = getSessionHistory()
+    if (history.length) setSessionHistory(history)
+    const last = getLastSessionId()
+    if (last) setSessionId(last)
+  }, [setSessionHistory, setSessionId])
+
+  useEffect(() => {
+    if (sessionId) {
+      addSessionToHistory(sessionId)
+      saveLastSessionId(sessionId)
+    }
+  }, [sessionId, addSessionToHistory])
+
+  useEffect(() => {
+    saveSessionHistory(sessionHistory)
+  }, [sessionHistory])
 
   useEffect(() => {
     const initializeSession = async (userId: string) => {
@@ -93,11 +121,12 @@ export default function StrategyPage() {
     <AuthWrapper>
       <ComingSoonScreen>
         <div
-          className="min-h-screen h-screen bg-black text-white pt-20 flex flex-col overflow-auto"
+          className="relative min-h-screen h-screen bg-black text-white pt-20 flex flex-col overflow-auto"
           style={{
             height: 'calc(100vh - 120px)',
           }}
         >
+          <SessionHistory />
           <div className="container mx-auto px-4 max-w-full h-full ">
             <div
               className={`flex flex-row gap-0 flex-1 h-full relative split-container ${!showSplit ? 'justify-center' : ''}`}

--- a/components/strategy/session-history.tsx
+++ b/components/strategy/session-history.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState } from 'react'
+import { List } from 'lucide-react'
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { useStrategyStore } from '@/stores/strategyStore'
+
+export default function SessionHistory() {
+  const sessionHistory = useStrategyStore((s) => s.sessionHistory)
+  const setSessionId = useStrategyStore((s) => s.setSessionId)
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="absolute left-2 top-2 z-20 bg-zinc-800/50 hover:bg-zinc-700"
+        >
+          <List className="w-5 h-5 text-white" />
+          <span className="sr-only">Toggle Sessions</span>
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="left"
+        className="w-60 bg-zinc-900 border-r border-zinc-700 text-white"
+      >
+        <h3 className="text-lg font-semibold mb-4">Sessions</h3>
+        {sessionHistory.length === 0 && (
+          <p className="text-zinc-400 text-sm">No sessions</p>
+        )}
+        {sessionHistory.length > 0 && (
+          <ul className="space-y-2">
+            {sessionHistory.map((id) => (
+              <li key={id}>
+                <Button
+                  variant="outline"
+                  className="w-full justify-start truncate"
+                  onClick={() => {
+                    setSessionId(id)
+                    setOpen(false)
+                  }}
+                >
+                  {id}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/stores/strategyStore.ts
+++ b/stores/strategyStore.ts
@@ -28,6 +28,10 @@ interface StrategyState {
   sessionId: string | null
   setSessionId: (id: string | null) => void
 
+  sessionHistory: string[]
+  setSessionHistory: (ids: string[]) => void
+  addSessionToHistory: (id: string) => void
+
   // APIバージョン設定を追加
   apiVersion: 'v0' | 'v1'
   setApiVersion: (version: 'v0' | 'v1') => void
@@ -57,6 +61,15 @@ interface StrategyState {
 export const useStrategyStore = create<StrategyState>((set) => ({
   sessionId: null,
   setSessionId: (id) => set({ sessionId: id }),
+
+  sessionHistory: [],
+  setSessionHistory: (ids) => set({ sessionHistory: ids }),
+  addSessionToHistory: (id) =>
+    set((state) =>
+      state.sessionHistory.includes(id)
+        ? state
+        : { sessionHistory: [...state.sessionHistory, id] },
+    ),
 
   // APIバージョンのデフォルト値と更新関数
   apiVersion: defaultApiVersion,

--- a/utils/session-cookie.ts
+++ b/utils/session-cookie.ts
@@ -1,0 +1,40 @@
+export const SESSION_HISTORY_COOKIE = 'strategy:sessions'
+export const LAST_SESSION_COOKIE = 'strategy:lastSession'
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 30 // 30 days
+
+export function getSessionHistory(): string[] {
+  if (typeof document === 'undefined') return []
+  const match = document.cookie.match(
+    new RegExp(`${SESSION_HISTORY_COOKIE}=([^;]+)`),
+  )
+  if (match?.[1]) {
+    try {
+      return JSON.parse(decodeURIComponent(match[1])) as string[]
+    } catch {
+      return []
+    }
+  }
+  return []
+}
+
+export function saveSessionHistory(history: string[]) {
+  if (typeof document === 'undefined') return
+  document.cookie = `${SESSION_HISTORY_COOKIE}=${encodeURIComponent(
+    JSON.stringify(history),
+  )}; path=/; max-age=${COOKIE_MAX_AGE}`
+}
+
+export function getLastSessionId(): string | null {
+  if (typeof document === 'undefined') return null
+  const match = document.cookie.match(
+    new RegExp(`${LAST_SESSION_COOKIE}=([^;]+)`),
+  )
+  return match?.[1] ? decodeURIComponent(match[1]) : null
+}
+
+export function saveLastSessionId(id: string) {
+  if (typeof document === 'undefined') return
+  document.cookie = `${LAST_SESSION_COOKIE}=${encodeURIComponent(
+    id,
+  )}; path=/; max-age=${COOKIE_MAX_AGE}`
+}


### PR DESCRIPTION
## Summary
- persist session ids using cookies
- show cookie-backed session history in a toggleable sidebar

## Testing
- `npm run check`
- `npx next lint` *(fails: connect EHOSTUNREACH)*
